### PR TITLE
注文時日付指定がない時のエラーを解決

### DIFF
--- a/src/main/java/com/example/controller/OrderController.java
+++ b/src/main/java/com/example/controller/OrderController.java
@@ -33,6 +33,7 @@ public class OrderController {
 	@PostMapping("/orderinfosend")
 	public String orderInfoSend(@Validated OrderForm orderform, BindingResult result, Model model,
 			@AuthenticationPrincipal LoginUser loginUser,HttpServletRequest request) {
+		if(orderform.getOrderDate().equals("")) {return controller.orderPost(model, orderform, loginUser,request);}
 		LocalDateTime date = LocalDateTime.now();
 		DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
 		LocalDate dates = LocalDate.parse(orderform.getOrderDate(), formatter);


### PR DESCRIPTION
注文時日付指定がない時のエラーを解決しました。
日付フォームを指定しないと空欄で送信され、データ型のフォーマット時にエラーが出ていたところを修正しました。